### PR TITLE
ENG-24049 - File Name Length Trimming

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.adobe.granite.translation.connector</groupId>
         <artifactId>lilt-connector</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>lilt-connector.core</artifactId>

--- a/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
+++ b/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
@@ -538,11 +538,21 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
 
     @Override
     public void addTranslationObjectComment(String strTranslationJobID, TranslationObject translationObject,
-        Comment comment) throws TranslationException {
-        log.trace("BootstrapTranslationServiceImpl.addTranslationObjectComment");
-
-        throw new TranslationException("This function is not implemented",
-            TranslationException.ErrorCode.SERVICE_NOT_IMPLEMENTED);
+      Comment comment) throws TranslationException {
+      log.trace("BootstrapTranslationServiceImpl.addTranslationObjectComment");
+      String annotation = comment.getAnnotationData();
+      String author = comment.getAuthorName();
+      String fileName = String.format("%s_%s.txt");
+      String objectPath = String.format("%s.%s", getObjectPath(translationObject), exportFormat);
+      String message = comment.getMessage();
+      String body = String.format("%s\n\n%s", objectPath, message);
+      InputStream inputStream = new ByteArrayInputStream(body.getBytes());
+      String labels = String.format("%s,comment", strTranslationJobID);
+      try {
+        liltApiClient.uploadFile(fileName, labels, inputStream);
+      } catch (Exception e) {
+        log.warn("error during addTranslationObjectComment {}", e);
+      }
     }
 
     @Override

--- a/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
+++ b/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
@@ -294,14 +294,17 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
           boolean hasImported = imported > 0;
           boolean hasTranslated = translated > 0;
           if (hasImported && hasTranslated) {
+            log.warn("lilt: job status for {} is TRANSLATED", strTranslationJobID);
             return TranslationStatus.TRANSLATED;
           }
           if (hasImported) {
+            log.warn("lilt: job status for {} is TRANSLATION_IN_PROGRESS", strTranslationJobID);
             return TranslationStatus.TRANSLATION_IN_PROGRESS;
           }
         } catch (Exception e) {
           log.warn("error during getTranslationJobStatus {}", e);
         }
+        log.warn("lilt: job status for {} is COMMITTED_FOR_TRANSLATION", strTranslationJobID);
         return TranslationStatus.COMMITTED_FOR_TRANSLATION;
     }
 
@@ -323,13 +326,16 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
     public InputStream getTranslatedObject(String strTranslationJobID, TranslationObject translationObj)
       throws TranslationException {
       log.trace("BootstrapTranslationServiceImpl.getTranslatedObject");
+      log.warn("lilt: strTranslationJobID: {}", strTranslationJobID);
       String labels = String.format("%s,status=TRANSLATED", strTranslationJobID);
       String objectPath = String.format("%s.%s", getObjectPath(translationObj), exportFormat);
+      log.warn("lilt: checking for objectPath {}", objectPath);
       try {
         SourceFile[] files = liltApiClient.getFiles(labels);
         // loop backwards through the list since the most recent files will be at the end.
         for (int i = files.length - 1; i >= 0; i--) {
           SourceFile file = files[i];
+          log.warn("lilt: comparing {} to {}", file.name, objectPath);
           if (Objects.equals(file.name, objectPath)) {
             log.warn("Downloading the translated lilt file {}", file.id);
             String translation = liltApiClient.downloadFile(file.id);
@@ -409,11 +415,13 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
       log.trace("BootstrapTranslationServiceImpl.getTranslationObjectStatus");
       try {
         String objectPath = String.format("%s.%s", getObjectPath(translationObject), exportFormat);
+        log.warn("lilt: strTranslationJobID");
         int imported = 0;
         int translated = 0;
         SourceFile[] files = liltApiClient.getFiles(strTranslationJobID);
         // loop backwards through the list since the most recent files will be at the end.
         for (SourceFile file : files) {
+          log.warn("lilt: comparing {} to {}", file.name, objectPath);
           if (!Objects.equals(file.name, objectPath)) {
             continue;
           }
@@ -427,16 +435,20 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
         boolean hasImported = imported > 0;
         boolean hasTranslated = translated > 0;
         if (hasImported && hasTranslated) {
+          log.warn("lilt: status for {} is TRANSLATED", objectPath);
           return TranslationStatus.TRANSLATED;
         }
         if (hasImported) {
+          log.warn("lilt: status for {} is TRANSLATION_IN_PROGRESS", objectPath);
           return TranslationStatus.TRANSLATION_IN_PROGRESS;
         }
         // if the object has an extension then it is an image or some sort of asset. we should consider those translated.
         Optional<String> maybeExt = getFileExtension(objectPath);
         if (maybeExt.isPresent()) {
+          log.warn("lilt: status for {} is TRANSLATED", objectPath);
           return TranslationStatus.TRANSLATED;
-      }
+        }
+        log.warn("lilt: status for {} is COMMITTED_FOR_TRANSLATION", objectPath);
       } catch (Exception e) {
         log.warn("error during getTranslationObjectStatus {}", e);
       }

--- a/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
+++ b/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
@@ -564,9 +564,8 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
             TranslationException.ErrorCode.SERVICE_NOT_IMPLEMENTED);
     }
 
-    
+
     private String getObjectPath (TranslationObject translationObject){
-        
         if(translationObject.getTranslationObjectSourcePath()!= null && !translationObject.getTranslationObjectSourcePath().isEmpty()){
             return  translationObject.getTranslationObjectSourcePath();
         }
@@ -575,19 +574,19 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
         }
         else if(translationObject.getTitle().equals("ASSETMETADATA")){
             return ASSET_METADATA;
-        } 
+        }
         else if(translationObject.getTitle().equals("I18NCOMPONENTSTRINGDICT")){
             return I18NCOMPONENTSTRINGDICT;
         }
         return null;
-    }    
+    }
 
     public void updateDueDate(String strTranslationJobID, Date date)
             throws TranslationException {
             log.debug("NEW DUE DATE:{}",date);
             // bootstrapTmsService.setTmsJobDuedate(strTranslationJobID, date);
     }
-    
+
 	private static void unzipFileFromStream(ZipInputStream zipInputStream, String targetPath) throws IOException {
 		File dirFile = new File(targetPath + File.separator);
 		if (!dirFile.exists()) {

--- a/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
+++ b/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
@@ -417,9 +417,10 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
       TranslationObject translationObject, TranslationState state) throws TranslationException {
       log.trace("BootstrapTranslationServiceImpl.updateTranslationObjectState");
       log.warn("lilt: strTranslationJobID: {}", strTranslationJobID);
+      String labels = String.format("%s,status=TRANSLATED", strTranslationJobID);
       String status = state.getStatus().toString();
       String label = String.format("approval=%s", status);
-      String objectPath = String.format("%s.%s", getObjectPath(translationObj), exportFormat);
+      String objectPath = String.format("%s.%s", getObjectPath(translationObject), exportFormat);
       log.warn("lilt: checking for objectPath {}", objectPath);
       try {
         SourceFile[] files = liltApiClient.getFiles(labels);
@@ -470,7 +471,6 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
           }
         }
         boolean hasImported = imported > 0;
-        boolean hasTranslated = translated > 0;
         boolean hasTranslated = translated > 0;
         boolean hasRejected = rejected > 0;
         if (hasImported && hasTranslated && approved >= imported) {

--- a/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
+++ b/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/BootstrapTranslationServiceImpl.java
@@ -304,6 +304,10 @@ public class BootstrapTranslationServiceImpl extends AbstractTranslationService 
             log.warn("lilt: job status for {} is APPROVED", strTranslationJobID);
             return TranslationStatus.APPROVED;
           }
+          if (hasImported && hasTranslated && hasRejected) {
+            log.info("lilt: job status for {} is TRANSLATION_IN_PROGRESS", strTranslationJobID);
+            return TranslationStatus.TRANSLATION_IN_PROGRESS;
+          }
           if (hasImported && hasTranslated) {
             log.warn("lilt: job status for {} is TRANSLATED", strTranslationJobID);
             return TranslationStatus.TRANSLATED;

--- a/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/LiltApiClient.java
+++ b/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/LiltApiClient.java
@@ -6,11 +6,14 @@ import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
@@ -98,6 +101,22 @@ public class LiltApiClient {
       return new BufferedReader(new InputStreamReader(content, StandardCharsets.UTF_8))
         .lines()
         .collect(Collectors.joining("\n"));
+    }
+  }
+
+  public void addLabel(Integer fileId, String label) throws IOException, URISyntaxException {
+    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+      String baseUrl = String.format("%s/files/labels", apiUrl);
+      URIBuilder req = new URIBuilder(baseUrl);
+      HttpPost httppost = new HttpPost(req.build());
+      HashMap<String, String> reqBody = new HashMap<>();
+      reqBody.put("name", label);
+      Gson gson = new Gson();
+      String jsonBody = gson.toJson(reqBody);
+      HttpEntity body = new StringEntity(jsonBody, ContentType.APPLICATION_JSON);
+      httppost.setEntity(body);
+      log.warn("Executing request {}", httppost.getRequestLine());
+      httpclient.execute(httppost);
     }
   }
 }

--- a/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/LiltApiClient.java
+++ b/core/src/main/java/com/adobe/granite/translation/connector/bootstrap/core/impl/LiltApiClient.java
@@ -106,13 +106,17 @@ public class LiltApiClient {
 
   public void addLabel(Integer fileId, String label) throws IOException, URISyntaxException {
     try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+      log.warn("addLabel fileId {}", fileId);
       String baseUrl = String.format("%s/files/labels", apiUrl);
       URIBuilder req = new URIBuilder(baseUrl);
+      req.setParameter("id", Integer.toString(fileId));
+      req.setParameter("key", apiKey);
       HttpPost httppost = new HttpPost(req.build());
       HashMap<String, String> reqBody = new HashMap<>();
       reqBody.put("name", label);
       Gson gson = new Gson();
       String jsonBody = gson.toJson(reqBody);
+      log.warn("addLabel body {}", jsonBody);
       HttpEntity body = new StringEntity(jsonBody, ContentType.APPLICATION_JSON);
       httppost.setEntity(body);
       log.warn("Executing request {}", httppost.getRequestLine());

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>lilt-connector</artifactId>
     <name>Lilt Translation Connector</name>
     <packaging>pom</packaging>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.2</version>
     <description>Lilt Translation Connector</description>
 
     <modules>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.granite.translation.connector</groupId>
         <artifactId>lilt-connector</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This PR's primary purpose is to trim the length of the filename sent to lilt to 200 characters. This PR also includes the other changes that are from the `handle_approve_reject_comments` branch, which appears to be the last used branch.